### PR TITLE
refactor: reorganize overall code structure

### DIFF
--- a/c_src/scitree/scitree.cpp
+++ b/c_src/scitree/scitree.cpp
@@ -67,7 +67,7 @@ static ERL_NIF_TERM train(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   train_config.set_learner(config.learner);
   train_config.set_task(config.task);
   train_config.set_label(config.label);
-  
+
   // Create types dataspec
   ygg::dataset::proto::DataSpecification spec;
   ygg::dataset::VerticalDataset dataset;
@@ -82,7 +82,7 @@ static ERL_NIF_TERM train(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     return scitree::nif::error(env, error_dataset.reason.c_str());
   }
 
-  // Config leaener
+  // Config learner
   std::unique_ptr<ygg::model::AbstractLearner> learner;
   GetLearner(train_config, &learner);
 
@@ -119,7 +119,7 @@ static ERL_NIF_TERM predict(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
   ERL_NIF_TERM* tuple_dataset;
 
   enif_get_tuple(env, argv[1], &size_dataset, &tuple_dataset);
-  
+
   if (size_dataset <= 0) {
     return scitree::nif::error(env, "Empty or invalid dataset.");
   }
@@ -147,27 +147,31 @@ static ERL_NIF_TERM predict(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
   ygg::serving::CopyVerticalDatasetToAbstractExampleSet(
       dataset_predit, 0, num_row -1, features, examples.get()
   );
-  
+
   std::vector<float> batch_of_predictions;
   serving_engine->Predict(*examples, num_row, &batch_of_predictions);
-  int batch_size = batch_of_predictions.size();
-  int qtt_category_types = trunc(batch_size / num_row);
+  const int batch_size = batch_of_predictions.size();
+  const int qtt_category_types = batch_size / num_row;
 
-  ERL_NIF_TERM predictions[batch_size];
+  // allocate potentially large array in the heap instead of the stack
+  ERL_NIF_TERM *predictions = new ERL_NIF_TERM[batch_size];
 
-  int i = 0;
-  for (const float prediction : batch_of_predictions) {
+  for (size_t i = 0; i < batch_size; i++) {
+    const float prediction = batch_of_predictions[i];
+
     if ((**p_model).task() == ygg::model::proto::Task::CLASSIFICATION) {
       float class_prediction = std::clamp(prediction, 0.f, 1.f);
       predictions[i] = enif_make_double(env, class_prediction);
     } else {
       predictions[i] = enif_make_double(env, prediction);
     }
-    i++;
   }
 
   ERL_NIF_TERM chunk = enif_make_int(env, qtt_category_types);
-  ERL_NIF_TERM list = enif_make_list_from_array(env, predictions, batch_of_predictions.size());
+  ERL_NIF_TERM list = enif_make_list_from_array(env, predictions, batch_size);
+
+  // deallocate predictions array
+  delete [] predictions;
 
   return enif_make_tuple3(env, scitree::nif::ok(env), list, chunk);
 }
@@ -200,7 +204,7 @@ static ERL_NIF_TERM load(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   std::unique_ptr<ygg::model::AbstractModel> model;
 
   LoadModel(path, &model);
-  
+
   // prepare resource
   ygg::model::AbstractModel **p_model;
   p_model = (ygg::model::AbstractModel **)enif_alloc_resource(RES_TYPE, sizeof(ygg::model::AbstractModel *));

--- a/c_src/scitree/scitree_nif_helper.hpp
+++ b/c_src/scitree/scitree_nif_helper.hpp
@@ -109,7 +109,7 @@ int get(ErlNifEnv *env, ERL_NIF_TERM term, real *var) {
     return 0;
 }
 
-// atom's
+// atoms
 int get_atom(ErlNifEnv *env, ERL_NIF_TERM term, std::string &var) {
     unsigned atom_length;
     if (!enif_get_atom_length(env, term, &atom_length, ERL_NIF_LATIN1)) {
@@ -123,6 +123,25 @@ int get_atom(ErlNifEnv *env, ERL_NIF_TERM term, std::string &var) {
 
     var.resize(atom_length);
 
+    return 1;
+}
+
+// lists
+int get_list(ErlNifEnv *env,
+             ERL_NIF_TERM list,
+             std::vector<ERL_NIF_TERM> &var)
+{
+    unsigned int length;
+    if (!enif_get_list_length(env, list, &length))
+        return 0;
+    var.reserve(length);
+    ERL_NIF_TERM head, tail;
+
+    while (enif_get_list_cell(env, list, &head, &tail))
+    {
+        var.push_back(head);
+        list = tail;
+    }
     return 1;
 }
 

--- a/lib/scitree/config.ex
+++ b/lib/scitree/config.ex
@@ -3,14 +3,14 @@ defmodule Scitree.Config do
 
   @type learners :: :cart | :gradient_boosted_trees | :random_forest
 
-  @options %{
+  @default_options [
     maximum_model_size_in_memory_in_bytes: -1.0,
     maximum_training_duration_seconds: -1.0,
     random_seed: 123_456
-  }
+  ]
 
   defstruct learner: :gradient_boosted_trees,
-            options: @options,
+            options: @default_options,
             task: :classification,
             label: "",
             log_directory: ""
@@ -27,11 +27,11 @@ defmodule Scitree.Config do
         label: "",
         learner: :gradient_boosted_trees,
         log_directory: "",
-        options: %{
+        options: [
           maximum_model_size_in_memory_in_bytes: -1.0,
           maximum_training_duration_seconds: -1.0,
           random_seed: 123456
-        },
+        ],
         task: :classification
       }
   """
@@ -50,11 +50,11 @@ defmodule Scitree.Config do
         label: "",
         learner: :random_forest,
         log_directory: "",
-        options: %{
+        options: [
           maximum_model_size_in_memory_in_bytes: -1.0,
           maximum_training_duration_seconds: -1.0,
           random_seed: 123456
-        },
+        ],
         task: :classification
       }
 
@@ -75,28 +75,26 @@ defmodule Scitree.Config do
         label: "",
         learner: :random_forest,
         log_directory: "",
-        options: %{
+        options: [
           maximum_model_size_in_memory_in_bytes: -1.0,
           maximum_training_duration_seconds: -1.0,
           random_seed: 654321
-        },
+        ],
         task: :classification
       }
   """
   @spec learner(t(), learners(), list()) :: t()
   def learner(config, learner, opts \\ []) do
-    options = Enum.into(opts, @options)
+    options = Keyword.validate!(opts, @default_options)
 
-    config
-    |> Map.put(:options, options)
-    |> Map.put(:learner, learner)
+    %{config | options: options, learner: learner}
   end
 
   @spec task(t(), tasks()) :: t()
-  def task(config, type), do: Map.put(config, :task, type)
+  def task(config, type), do: %{config | task: type}
 
   @spec label(t(), String.t()) :: t()
-  def label(config, label), do: Map.put(config, :label, label)
+  def label(config, label), do: %{config | label: label}
 
   @doc """
   Set a directory to save training logs
@@ -108,14 +106,14 @@ defmodule Scitree.Config do
         label: "",
         learner: :gradient_boosted_trees,
         log_directory: "/path",
-        options: %{
+        options: [
           maximum_model_size_in_memory_in_bytes: -1.0,
           maximum_training_duration_seconds: -1.0,
           random_seed: 123456
-        },
+        ],
         task: :classification
       }
   """
   @spec log_directory(t(), String.t()) :: t()
-  def log_directory(config, dir), do: Map.put(config, :log_directory, dir)
+  def log_directory(config, dir), do: %{config | log_directory: dir}
 end

--- a/lib/scitree/infer.ex
+++ b/lib/scitree/infer.ex
@@ -1,37 +1,24 @@
 defmodule Scitree.Infer do
   @doc """
-  Returns a tuple with the title, type and data.
+  Returns a list of `{title, type, data}`-tuples.
 
   ## Examples
       iex> data = %{:id => [1, 2, 3], :title => ["a", "b", "c"]}
       iex> Scitree.Inference.execute(data)
-      {{"id", :categorical, [1, 2, 3]},
-       {"title", :string, ["a", "b", "c"]}}
+      [{"id", :categorical, [1, 2, 3]},
+       {"title", :string, ["a", "b", "c"]}]
   """
   def execute(data) do
-    data
-    |> infer()
-    |> normalize()
-  end
+    for {title, [val | _] = values} <- data do
+      inferred_type = infer_column_type(val)
 
-  defp infer(data) do
-    for {title, values} <- data,
-        [val | _] = values do
-      cond do
-        is_integer(val) -> {title, :categorical, values}
-        is_boolean(val) -> {title, :categorical, values}
-        is_float(val) -> {title, :numerical, values}
-        is_binary(val) -> {title, :string, values}
-        true -> {title, :unknown, values}
-      end
+      {to_string(title), inferred_type, values}
     end
   end
 
-  defp normalize(data) do
-    for {title, type, values} <- data do
-      str_title = if is_atom(title), do: Atom.to_string(title), else: title
-      {str_title, type, values}
-    end
-    |> List.to_tuple()
-  end
+  defp infer_column_type(val) when is_integer(val), do: :categorical
+  defp infer_column_type(val) when is_boolean(val), do: :categorical
+  defp infer_column_type(val) when is_float(val), do: :numerical
+  defp infer_column_type(val) when is_binary(val), do: :string
+  defp infer_column_type(_), do: :unknown
 end

--- a/lib/scitree/predictions.ex
+++ b/lib/scitree/predictions.ex
@@ -3,7 +3,7 @@ defmodule Scitree.Predictions do
   Convert probabilities to predicted class.
   This function will return the index of the class it is likely to be.
 
-  The zero value in yggdrasil is reserved for values outside the dictionary.
+  The zero value in Yggdrasil is reserved for values outside the dictionary.
 
   ## Examples
     iex> pred = Nx.tensor([[0.01, 0.98, 0.1], [0.00, 0.01, 0.99]])

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
+  "nx": {:hex, :nx, "0.1.0", "8f8a047dc0fd2b1798406edf828b43c46cca648b13c58fd5abd52285316b3d86", [:mix], [], "hexpm", "24ce6e184dc9c7b7c6c247923bfbe994101a7fe049bd3fd376b5b0512f787256"},
+  "scholar": {:git, "https://github.com/elixir-nx/scholar.git", "6ae1f64d58886f47d5c27d0c4636eb92a16daeb9", []},
+}


### PR DESCRIPTION
This PR:

- fixes a potential bug in the predictions array allocation
- changes the model structure from an n-tuple of 3-tuples to a list of 3-tuples
- simplifies validation code
- simplifies inference code